### PR TITLE
Enhanced the "unrecognized opcode" error message

### DIFF
--- a/phpserialize.py
+++ b/phpserialize.py
@@ -507,7 +507,7 @@ def load(fp, charset='utf-8', errors=default_errors, decode_strings=False,
             if decode_strings:
                 name = name.decode(charset, errors)
             return object_hook(name, dict(_load_array()))
-        raise ValueError('unexpected opcode')
+        raise ValueError('unexpected opcode - %s' % repr(type_))
 
     return _unserialize()
 


### PR DESCRIPTION
Since other exception messages also include the details of what data was wrong, 
I appended the unrecognizable opcode to the message after I had to debug a 
non-deserializeable string in our system.
