### PR TITLE
fix ValueError('dict is not a sequence'), many times KeyError of 0, beca...

### DIFF
--- a/phpserialize.py
+++ b/phpserialize.py
@@ -545,7 +545,7 @@ def dict_to_list(d):
     # array_hook.
     d = dict(d)
     try:
-        return [d[x] for x in xrange(len(d))]
+        return [d[x] for x in d.keys()]
     except KeyError:
         raise ValueError('dict is not a sequence')
 


### PR DESCRIPTION
fix ValueError('dict is not a sequence'), many times KeyError of 0, because

xrange(len(2))->[0,1], not d.keys(), which raise KeyError