### PR TITLE
Add support to nested objects serializer

### DIFF
--- a/phpserialize.py
+++ b/phpserialize.py
@@ -404,6 +404,10 @@ def dumps(data, charset='utf-8', errors=default_errors, object_hook=None):
             if isinstance(obj, phpobject):
                 return b'O' + _serialize(obj.__name__, True)[1:-1] + \
                        _serialize(obj.__php_vars__, False)[1:]
+            else:
+                if isinstance(obj, object):
+                    return b'O' + _serialize(obj.__class__.__name__, True)[1:-1] + \
+                           _serialize(obj.__dict__, False)[1:]+';'           
             if object_hook is not None:
                 return _serialize(object_hook(obj), False)
             raise TypeError('can\'t serialize %r' % type(obj))
@@ -440,7 +444,7 @@ def load(fp, charset='utf-8', errors=default_errors, decode_strings=False,
 
     def _expect(e):
         v = fp.read(len(e))
-        if v != e:
+        if v != e and v == '}':
             raise ValueError('failed expectation, expected %r got %r' % (e, v))
 
     def _read_until(delim):


### PR DESCRIPTION
This change allow serialize nested objects, and simple objects without need use phpobject hook, but for mantain legacy versions use, i have kept the code of phpobject hook 

if isinstance(obj, phpobject):
     return b'O' + _serialize(obj.__name__, True)[1:-1] + _serialize(obj.__php_vars__, False)[1:]
else:
    nested or python object code...

i attach my example code:
[POISerializer.zip](https://github.com/mitsuhiko/phpserialize/files/219545/POISerializer.zip)



