### PR TITLE
Fix DeprecationError when ussing assert_ since python 3.12

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -88,7 +88,7 @@ class PhpSerializeTestCase(unittest.TestCase):
         x = phpserialize.dumps(user, object_hook=dump_object_hook)
         y = phpserialize.loads(x, object_hook=load_object_hook,
                                decode_strings=True)
-        self.assertTrue(b'WP_User' in x)
+        self.assertIn(b'WP_User', x)
         self.assertEqual(type(y), type(user))
         self.assertEqual(y.username, user.username)
 

--- a/tests.py
+++ b/tests.py
@@ -88,7 +88,7 @@ class PhpSerializeTestCase(unittest.TestCase):
         x = phpserialize.dumps(user, object_hook=dump_object_hook)
         y = phpserialize.loads(x, object_hook=load_object_hook,
                                decode_strings=True)
-        self.assert_(b'WP_User' in x)
+        self.assertTrue(b'WP_User' in x)
         self.assertEqual(type(y), type(user))
         self.assertEqual(y.username, user.username)
 


### PR DESCRIPTION
Dear Maintainer,

In Ubuntu we cannot build this package (FTBFS): since python3.12, the assert_ method no longer exists [1]. We could see a deprecation warning for this in previous builds, like this one for Focal [2]:

test_object_hook (tests.PhpSerializeTestCase) ... /<<PKGBUILDDIR>>/tests.py:92: DeprecationWarning: Please use assertTrue instead.
  self.assert_(b'WP_User' in x)

In Debian, they still use Python3.11 (so they have the warning, not the error like us) [3].

I'm submitting here the change that we have already incorporated into the Ubuntu package for your awareness in case you find it useful.

Thanks in advance!

[1] https://docs.python.org/3/library/unittest.html#assert-methods
[2] https://launchpadlibrarian.net/448504127/buildlog_ubuntu-focal-amd64.python-phpserialize_1.3-1.1_BUILDING.txt.gz
[3] https://buildd.debian.org/status/fetch.php?pkg=python-phpserialize&arch=all&ver=1.3-2&stamp=1712878490&raw=0